### PR TITLE
Fixed starvation issue when connecting synchronously.

### DIFF
--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -72,8 +72,9 @@
     <Compile Include="ConnectToUnexistingHost.cs" />
     <Compile Include="HyperLogLog.cs" />
     <Compile Include="Issues\DefaultDatabase.cs" />
-	<Compile Include="Profiling.cs" />
+    <Compile Include="Profiling.cs" />
     <Compile Include="Issues\Issue182.cs" />
+    <Compile Include="TaskManagerTests.cs" />
     <Compile Include="WrapperBaseTests.cs" />
     <Compile Include="TransactionWrapperTests.cs" />
     <Compile Include="Bits.cs" />

--- a/StackExchange.Redis.Tests/TaskManagerTests.cs
+++ b/StackExchange.Redis.Tests/TaskManagerTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace StackExchange.Redis.Tests
+{
+    [TestFixture]
+    public class TaskManagerTests
+    {
+        [Test]
+        public void TestExecuteNormal()
+        {
+            var ids = new List<int>();
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+            Trace.WriteLine("0) Thread: " + threadId);
+            var result = TaskManager.Execute(async () =>
+            {
+                Trace.WriteLine("1) Thread: " + Thread.CurrentThread.ManagedThreadId);
+                ids.Add(Thread.CurrentThread.ManagedThreadId);
+                await Task.Yield();
+                Trace.WriteLine("2) Thread: " + Thread.CurrentThread.ManagedThreadId);
+                ids.Add(Thread.CurrentThread.ManagedThreadId);
+                await Task.Delay(50).ForAwait();
+                Trace.WriteLine("3) Thread: " + Thread.CurrentThread.ManagedThreadId);
+                ids.Add(Thread.CurrentThread.ManagedThreadId);
+                Task t1 = Subtask(4, 1), t2 = Subtask(4, 2), t3 = Subtask(4, 3);
+                await Task.WhenAll(t1, t2, t3);
+                Trace.WriteLine("5) Thread: " + Thread.CurrentThread.ManagedThreadId);
+            }, 2000);
+            Assert.AreEqual(true, result);
+            CollectionAssert.AreEqual(ids, Enumerable.Repeat(threadId, 3).ToList());
+        }
+
+        static async Task Subtask(int step, int subtask)
+        {
+            await Task.Delay(30);
+            Trace.WriteLine(string.Format("{0}) Thread: {1} (Subtask {2})", step, Thread.CurrentThread.ManagedThreadId, subtask));
+        }
+
+        [Test]
+        public void TestExecuteTimeout()
+        {
+            int id1 = -1, id2 = -1;
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+            Trace.WriteLine("0) Thread: " + threadId);
+            using (var handle = new ManualResetEvent(false))
+            {
+                var result = TaskManager.Execute(async () =>
+                {
+                    Trace.WriteLine("1) Thread: " + Thread.CurrentThread.ManagedThreadId);
+                    id1 = Thread.CurrentThread.ManagedThreadId;
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    Trace.WriteLine("2) Thread: " + Thread.CurrentThread.ManagedThreadId);
+                    id2 = Thread.CurrentThread.ManagedThreadId;
+                    handle.Set();
+                }, 100);
+                Assert.AreEqual(false, result);
+                Assert.AreEqual(true, handle.WaitOne(5000));
+                Assert.AreEqual(threadId, id1);
+                Assert.AreNotEqual(threadId, id2);
+            }
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange.Redis.StrongName.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.StrongName.csproj
@@ -161,6 +161,7 @@
     <Compile Include="StackExchange\Redis\SortedSetEntry.cs" />
     <Compile Include="StackExchange\Redis\SortType.cs" />
     <Compile Include="StackExchange\Redis\StringSplits.cs" />
+    <Compile Include="StackExchange\Redis\TaskManager.cs" />
     <Compile Include="StackExchange\Redis\TaskSource.cs" />
     <Compile Include="StackExchange\Redis\When.cs" />
     <Compile Include="StackExchange\Redis\ShutdownMode.cs" />

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -155,6 +155,7 @@
     <Compile Include="StackExchange\Redis\SortedSetEntry.cs" />
     <Compile Include="StackExchange\Redis\SortType.cs" />
     <Compile Include="StackExchange\Redis\StringSplits.cs" />
+    <Compile Include="StackExchange\Redis\TaskManager.cs" />
     <Compile Include="StackExchange\Redis\TaskSource.cs" />
     <Compile Include="StackExchange\Redis\When.cs" />
     <Compile Include="StackExchange\Redis\ShutdownMode.cs" />

--- a/StackExchange.Redis/StackExchange/Redis/TaskManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/TaskManager.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis
+{
+    internal static class TaskManager
+    {
+        public static bool Execute(Func<Task> action, int timeout)
+        {
+            var oldContext = SynchronizationContext.Current;
+            var context = new SychronousSynchronizationContext(oldContext);
+            SynchronizationContext.SetSynchronizationContext(context);
+            var oldContinueOnCapturedContext = TaskExtensions.ContinueOnCapturedContext;
+            TaskExtensions.ContinueOnCapturedContext = true;
+            try
+            {
+                return context.ExecuteImpl(action, timeout);
+            }
+            finally
+            {
+                TaskExtensions.ContinueOnCapturedContext = oldContinueOnCapturedContext;
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
+
+        private class SychronousSynchronizationContext : SynchronizationContext
+        {
+            readonly Queue<Action> _pendingOperations = new Queue<Action>();
+            readonly SynchronizationContext _postCompletionContext;
+            bool _complete;
+
+            public SychronousSynchronizationContext(SynchronizationContext postCompletionContext)
+            {
+                _postCompletionContext = postCompletionContext;
+            }
+
+            public bool ExecuteImpl(Func<Task> action, int timeout)
+            {
+                lock (_pendingOperations)
+                {
+                    try
+                    {
+                        var dueBy = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeout);
+                        var task = action();
+                        task.ContinueWith(SetComplete, TaskContinuationOptions.ExecuteSynchronously);
+                        while (true)
+                        {
+                            while (_pendingOperations.Count == 0 && !_complete)
+                            {
+                                var waitFor = (int)(dueBy - DateTime.UtcNow).TotalMilliseconds;
+                                if (waitFor <= 0) return false;
+                                if (!Monitor.Wait(_pendingOperations, waitFor)) return false;
+                            }
+                            while (_pendingOperations.Count > 0)
+                            {
+                                _pendingOperations.Dequeue()();
+                            }
+                            if (_complete) break;
+                        }
+                        return true;
+                    }
+                    finally
+                    {
+                        _complete = true;
+                    }
+                }
+            }
+
+            private void SetComplete(Task task)
+            {
+                lock (_pendingOperations)
+                {
+                    _complete = true;
+                    Monitor.Pulse(_pendingOperations);
+                }
+            }
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                Action operation = () => d(state);
+                bool scheduled = false;
+                lock (_pendingOperations)
+                {
+                    if (!_complete)
+                    {
+                        Debug.WriteLine("Post from (sync): " + Thread.CurrentThread.ManagedThreadId);
+                        _pendingOperations.Enqueue(operation);
+                        scheduled = true;
+                        Monitor.Pulse(_pendingOperations);
+                    }
+                }
+                if (!scheduled)
+                {
+                    // If some sub-tasks don't complete until after the parent task completes,
+                    // post completion to the original synchronization context.
+                    Debug.WriteLine("Post from (async): " + Thread.CurrentThread.ManagedThreadId);
+                    if (_postCompletionContext == null)
+                    {
+                        ThreadPool.QueueUserWorkItem(o => d(state));
+                    }
+                    else
+                    {
+                        _postCompletionContext.Post(d, state);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If the worker pool is too busy to handle await
callbacks it can make it very difficult for a connect
operation to complete without timing out. This change
forces the await callbacks to run on the thread that
invokes the Connect operation, ensuring that a thread
is always available while connecting synchronously.
